### PR TITLE
Android SDK access 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,15 +12,32 @@ on:
     - '**.rs'
     - '**.toml'
 jobs:
-  test-and-check:
+  clean:
     name: Check code format
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
       - uses: actions-rs/toolchain@v1
         with:
+          profile: minimal
           toolchain: nightly
           components: rustfmt, clippy
+          override: true
+      - name: Check the format
+        run: cargo +nightly fmt --all -- --check
+      - name: Run clippy
+        run: cargo clippy --all-targets --all-features -- -D warnings -A clippy::upper_case_acronyms
+      - name: Check for deadlinks
+        run: |
+          cargo install cargo-deadlinks
+          cargo deadlinks --check-http
+
+  run-tests:
+      - uses: actions/checkout@master
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
           override: true
       - name: Setup Android SDK
         uses: android-actions/setup-android@v2
@@ -28,15 +45,6 @@ jobs:
         run: |
           wget https://github.com/google/bundletool/releases/download/1.8.2/bundletool-all-1.8.2.jar
           mv bundletool-all-1.8.2.jar $HOME/bundletool.jar
-      - name: Check the format
-        run: cargo +nightly fmt --all -- --check
-      - name: Run clippy
-        run: cargo clippy --all-targets --all-features -- -D warnings -A clippy::upper_case_acronyms
-      - name: Run tests
         run: |
           export BUNDLETOOL_PATH="$HOME/bundletool.jar"
-          cargo test --no-fail-fast
-      - name: Check for deadlinks
-        run: |
-          cargo install cargo-deadlinks
-          cargo deadlinks --check-http || true
+          cargo test --all

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,9 @@ jobs:
           cargo deadlinks --check-http
 
   run-tests:
+    name: Run tests
+    runs-on: macos-latest
+    steps:
       - uses: actions/checkout@master
       - uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
         run: |
           wget https://github.com/google/bundletool/releases/download/1.8.2/bundletool-all-1.8.2.jar
           mv bundletool-all-1.8.2.jar $HOME/bundletool.jar
-          export BUNDLETOOL_PATH="$HOME/bundletool.jar"
-        - name: Run tests
+      - name: Run tests
         run: |
+          export BUNDLETOOL_PATH="$HOME/bundletool.jar"
           cargo test --all

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,7 @@ jobs:
         run: |
           wget https://github.com/google/bundletool/releases/download/1.8.2/bundletool-all-1.8.2.jar
           mv bundletool-all-1.8.2.jar $HOME/bundletool.jar
-        run: |
           export BUNDLETOOL_PATH="$HOME/bundletool.jar"
+        - name: Run tests
+        run: |
           cargo test --all

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,10 +27,6 @@ jobs:
         run: cargo +nightly fmt --all -- --check
       - name: Run clippy
         run: cargo clippy --all-targets --all-features -- -D warnings -A clippy::upper_case_acronyms
-      - name: Check for deadlinks
-        run: |
-          cargo install cargo-deadlinks
-          cargo deadlinks --check-http
 
   run-tests:
     name: Run tests

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ displaydoc = "0.2"
 walkdir = "2.3"
 dirs = { version = "4.0.0", optional = true }
 which = { version = "4.2.2", optional = true }
+serde = { version = "1.0", features = ["derive"] }
 
 [dev-dependencies]
 tempfile = "3.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "android-tools"
-version = "0.2.8"
+version = "0.2.9"
 edition = "2021"
 authors = ["DodoRare Team <support@dodorare.com>"]
 description = "Android-related tools for building and developing applications 🛠"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ displaydoc = "0.2"
 walkdir = "2.3"
 dirs = { version = "4.0.0", optional = true }
 which = { version = "4.2.2", optional = true }
-serde = { version = "1.0", features = ["derive"] }
 
 [dev-dependencies]
 tempfile = "3.2"

--- a/src/aapt2/mod.rs
+++ b/src/aapt2/mod.rs
@@ -26,7 +26,7 @@ pub use optimize::*;
 pub use version::*;
 
 use self::{daemon::Aapt2Daemon, diff::Aapt2Diff, version::Aapt2Version};
-use crate::{error::*, sdk_path_from_env, find_max_version};
+use crate::{error::*, find_max_version, sdk_path_from_env};
 use std::{
     path::{Path, PathBuf},
     process::Command,

--- a/src/aapt2/mod.rs
+++ b/src/aapt2/mod.rs
@@ -26,7 +26,7 @@ pub use optimize::*;
 pub use version::*;
 
 use self::{daemon::Aapt2Daemon, diff::Aapt2Diff, version::Aapt2Version};
-use crate::{error::*, sdk_path_from_env};
+use crate::{error::*, sdk_path_from_env, find_max_version};
 use std::{
     path::{Path, PathBuf},
     process::Command,
@@ -110,14 +110,7 @@ pub fn aapt2_tool() -> Result<Command> {
     }
     let sdk_path = sdk_path_from_env()?;
     let build_tools = sdk_path.join("build-tools");
-    let target_sdk_version = std::fs::read_dir(&build_tools)
-        .map_err(|_| Error::PathNotFound(build_tools.clone()))?
-        .filter_map(|path| path.ok())
-        .filter(|path| path.path().is_dir())
-        .filter_map(|path| path.file_name().into_string().ok())
-        .filter(|name| name.chars().next().unwrap().is_digit(10))
-        .max()
-        .ok_or(AndroidError::BuildToolsNotFound)?;
+    let target_sdk_version = find_max_version(&build_tools)?;
     let aapt2_exe = build_tools.join(target_sdk_version).join(bin!("aapt2"));
     Ok(Command::new(aapt2_exe))
 }

--- a/src/bundletool/build_apks.rs
+++ b/src/bundletool/build_apks.rs
@@ -28,7 +28,7 @@ use std::path::{Path, PathBuf};
 /// The table below describes the various flags and options you can set when using the
 /// `bundletool build-apks` command in greater detail. Only `--bundle` and `--output` are
 /// required—all other flags are optional
-#[derive(Debug, PartialEq, Default)]
+#[derive(Debug, Default)]
 pub struct BuildApks {
     bundle: PathBuf,
     output: PathBuf,
@@ -47,13 +47,13 @@ pub struct BuildApks {
     local_testing: bool,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 pub enum KsPass {
     KsPassPass,
     KsPassFile,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 pub enum KeyPass {
     KeyPassPass,
     KeyPassFile,

--- a/src/bundletool/build_bundle.rs
+++ b/src/bundletool/build_bundle.rs
@@ -15,7 +15,7 @@ use std::path::{Path, PathBuf};
 /// can not use apksigner to sign your app bundle.
 ///
 /// [jarsigner]: https://docs.oracle.com/javase/8/docs/technotes/tools/windows/jarsigner.html
-#[derive(Debug, PartialEq, PartialOrd)]
+#[derive(Debug)]
 pub struct BuildBundle {
     modules: Vec<PathBuf>,
     output: PathBuf,

--- a/src/bundletool/get_device_spec.rs
+++ b/src/bundletool/get_device_spec.rs
@@ -20,7 +20,7 @@ use std::path::{Path, PathBuf};
 /// `bundletool build-apks --device-spec=/MyApp/pixel2.json`
 /// `--bundle=/MyApp/my_app.aab --output=/MyApp/my_app.apks`
 /// ```
-#[derive(Debug, PartialEq, PartialOrd)]
+#[derive(Debug)]
 pub struct GetDeviceSpec {
     output: PathBuf,
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -9,6 +9,8 @@ pub type Result<T> = std::result::Result<T, Error>;
 /// Android specific error type
 #[derive(Display, Debug, Error)]
 pub enum AndroidError {
+    /// Android SDK or Android NDK is not found.
+    AndroidToolIsNotFound,
     /// Android SDK is not found
     AndroidSdkNotFound,
     /// Android NDK is not found

--- a/src/error.rs
+++ b/src/error.rs
@@ -43,7 +43,7 @@ pub enum Error {
     CmdNotFound(String),
     /// Command had a non-zero exit code. Stdout: {0} Stderr: {1}
     CmdFailed(String, String),
-    /// Bundletool is not found
+    /// Bundletool is not found. Please, use crossbundle install command to setup bundletool
     BundletoolNotFound,
     /// Compiled resources not found
     CompiledResourcesNotFound,

--- a/src/java_tools/keytool.rs
+++ b/src/java_tools/keytool.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 use crate::error::*;
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -785,8 +787,8 @@ impl Keytool {
     }
 
     /// Runs keytool commands
-    pub fn run(&self) -> Result<Option<AabKey>> {
-        let mut key = Some(AabKey::new_default()?);
+    pub fn run(&self) -> Result<Option<Key>> {
+        let mut key = Some(Key::new_default()?);
         let mut keytool = keytool()?;
         if self.v {
             keytool.arg("-v");
@@ -1023,14 +1025,14 @@ impl std::fmt::Display for KeyAlgorithm {
     }
 }
 
-#[derive(Debug, Clone)]
-pub struct AabKey {
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct Key {
     pub key_path: PathBuf,
     pub key_pass: String,
     pub key_alias: String,
 }
 
-impl AabKey {
+impl Key {
     pub fn new_default() -> Result<Self> {
         let key_path = android_dir()?.join("aab.keystore");
         let key_pass = "android".to_string();

--- a/src/java_tools/keytool.rs
+++ b/src/java_tools/keytool.rs
@@ -1,5 +1,3 @@
-use serde::{Deserialize, Serialize};
-
 use crate::error::*;
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -1025,7 +1023,7 @@ impl std::fmt::Display for KeyAlgorithm {
     }
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone)]
 pub struct Key {
     pub key_path: PathBuf,
     pub key_pass: String,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,7 +68,7 @@ pub fn find_max_version(target_dir: &std::path::Path) -> crate::error::Result<St
         .filter_map(|path| path.ok())
         .filter(|path| path.path().is_dir())
         .filter_map(|path| path.file_name().into_string().ok())
-        .filter(|name| name.chars().next().unwrap().is_digit(10))
+        .filter(|name| name.chars().next().unwrap().is_ascii_digit())
         .max()
         .ok_or(AndroidError::AndroidToolIsNotFound)?;
     Ok(max_version)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,7 @@
 use std::path::PathBuf;
 
+use error::AndroidError;
+
 /// On Windows adds `.exe` to given string.
 macro_rules! bin {
     ($bin:expr) => {{
@@ -59,4 +61,15 @@ pub fn sdk_install_path() -> crate::error::Result<PathBuf> {
         std::fs::create_dir_all(&sdk_path)?;
     }
     Ok(sdk_path)
+}
+
+pub fn find_max_version(target_dir: &std::path::Path) -> crate::error::Result<String> {
+    let max_version = std::fs::read_dir(&target_dir)?
+        .filter_map(|path| path.ok())
+        .filter(|path| path.path().is_dir())
+        .filter_map(|path| path.file_name().into_string().ok())
+        .filter(|name| name.chars().next().unwrap().is_digit(10))
+        .max()
+        .ok_or(AndroidError::AndroidToolIsNotFound)?;
+    Ok(max_version)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-use error::AndroidError;
 use std::path::PathBuf;
 
 /// On Windows adds `.exe` to given string.
@@ -31,7 +30,33 @@ pub fn sdk_path_from_env() -> crate::error::Result<PathBuf> {
             .ok()
             .or_else(|| std::env::var("ANDROID_SDK_PATH").ok())
             .or_else(|| std::env::var("ANDROID_HOME").ok());
-        std::path::PathBuf::from(sdk_path.ok_or(AndroidError::AndroidSdkNotFound)?)
+        std::path::PathBuf::from(
+            sdk_path.unwrap_or(sdk_install_path()?.to_str().unwrap().to_string()),
+        )
     };
+    Ok(sdk_path)
+}
+
+/// Default installation path
+pub fn sdk_install_path() -> crate::error::Result<PathBuf> {
+    let home_dir_path = dirs::home_dir().unwrap();
+    #[cfg(target_os = "windows")]
+    let path = std::path::Path::new("Local").join("Android").join("Sdk");
+    #[cfg(target_os = "macos")]
+    let path = std::path::Path::new("Library").join("Android").join("sdk");
+    #[cfg(target_os = "linux")]
+    let path = std::path::Path::new("Android").join("sdk");
+
+    #[cfg(target_os = "windows")]
+    let app_data = std::path::Path::new("AppData");
+    #[cfg(target_os = "windows")]
+    let sdk_path = home_dir_path.join(app_data).join(path);
+
+    #[cfg(not(target_os = "windows"))]
+    let sdk_path = home_dir_path.join(path);
+
+    if !sdk_path.exists() {
+        std::fs::create_dir_all(&sdk_path)?;
+    }
     Ok(sdk_path)
 }

--- a/tests/gen_key.rs
+++ b/tests/gen_key.rs
@@ -1,4 +1,4 @@
-use android_tools::java_tools::{android_dir, AabKey, KeyAlgorithm, Keytool};
+use android_tools::java_tools::{android_dir, Key, KeyAlgorithm, Keytool};
 
 #[test]
 /// The [`keytool`] command is a key and certificate management utility. It enables users to administer
@@ -34,7 +34,7 @@ fn test_create_keystore_with_keytool() {
     });
 
     // Creates new keystore from keytool
-    let key = AabKey::new_default().unwrap();
+    let key = Key::new_default().unwrap();
     Keytool::new()
         .genkeypair(true)
         .v(true)

--- a/tests/jarsigner.rs
+++ b/tests/jarsigner.rs
@@ -1,4 +1,4 @@
-use android_tools::java_tools::{android_dir, Key, JarSigner, KeyAlgorithm, Keytool};
+use android_tools::java_tools::{android_dir, JarSigner, Key, KeyAlgorithm, Keytool};
 
 #[test]
 /// The [`jarsigner`] tool has two purposes:

--- a/tests/jarsigner.rs
+++ b/tests/jarsigner.rs
@@ -1,4 +1,4 @@
-use android_tools::java_tools::{android_dir, AabKey, JarSigner, KeyAlgorithm, Keytool};
+use android_tools::java_tools::{android_dir, Key, JarSigner, KeyAlgorithm, Keytool};
 
 #[test]
 /// The [`jarsigner`] tool has two purposes:
@@ -39,7 +39,7 @@ fn test_sign_application_with_jarsigner() {
     });
 
     // Creates new keystore to sign aab
-    let key = AabKey::new_default().unwrap();
+    let key = Key::new_default().unwrap();
     Keytool::new()
         .genkeypair(true)
         .v(true)


### PR DESCRIPTION
# Objective 

  Add availability to get Android SDK directly from the default installation path.

# Solution

  Move out sdk_install_path() from crossbow to android-tools-rs to call Android SDK tools directly from the installation path, not only from ENV. 

# Migration guide

  Migrate android-tools-version from "0.2.8" to "0.2.9"